### PR TITLE
Improved performance of SRLS.

### DIFF
--- a/pylocus/algorithms.py
+++ b/pylocus/algorithms.py
@@ -200,7 +200,11 @@ def reconstruct_srls(edm, real_points, W=None, print_out=False, n=1, rescale=Fal
         anchors, w, r2 = get_lateration_parameters(real_points, indices, index,
                                                    edm, W)
         if print_out:
-            print('SRLS parameters:', anchors, w, r2)
+            print('SRLS parameters:')
+            print('anchors', anchors)
+            print('w', w)
+            print('r2', r2)
+
         srls = SRLS(anchors, w, r2, rescale, z, print_out)
         if rescale:
             srls = srls[0]  # second element of output is the scale

--- a/pylocus/lateration.py
+++ b/pylocus/lateration.py
@@ -74,7 +74,8 @@ def SRLS(anchors, w, r2, rescale=False, z=None, print_out=False):
 
     def phi(_lambda):
         yhat = y_hat(_lambda).reshape((-1, 1))
-        return np.dot(yhat.T, np.dot(D, yhat)) + 2 * np.dot(f.T, yhat)
+        sol = np.dot(yhat.T, np.dot(D, yhat)) + 2 * np.dot(f.T, yhat)
+        return sol.flatten()
 
     def phi_prime(_lambda):
         # TODO: test this.
@@ -94,7 +95,7 @@ def SRLS(anchors, w, r2, rescale=False, z=None, print_out=False):
         assert d == 3, 'Dimension of problem has to be 3 for fixing z.'
 
     if rescale and z is not None:
-        raise NotImplementedError('Canoot run rescale for fixed z.')
+        raise NotImplementedError('Cannot run rescale for fixed z.')
     if rescale and n < d + 2:
         raise ValueError(
             'A minimum of d + 2 ranges are necessary for rescaled ranging.')
@@ -148,32 +149,41 @@ def SRLS(anchors, w, r2, rescale=False, z=None, print_out=False):
         print('eigvals:', eigvals(ATA))
         print('condition number:', np.linalg.cond(ATA))
         print('generalized eigenvalues:', eig)
-    eps = 0.01
+
+    #eps = 0.01
     if eig[-1] > 1e-10:
-        I_orig = -1.0 / eig[-1] + eps
+        lower_bound = - 1.0 / eig[-1] 
     else:
         print('Warning: biggest eigenvalue is zero!')
-        I_orig = -1e-5
+        lower_bound = -1e-5
+
     inf = 1e5
     xtol = 1e-12
-    try:
-        lambda_opt = optimize.bisect(phi, I_orig, inf, xtol=xtol)
-    except:
-        print('Bisect failed. Trying Newton...')
-        lambda_opt = I_orig
-        try:
-            lambda_opt = optimize.newton(
-                phi, I_orig, fprime=phi_prime, maxiter=1000, tol=xtol)
-            assert phi(lambda_opt) < xtol, 'did not find solution of phi(lambda)=0:={}'.format(
-                phi(lambda_opt))
+
+    lambda_opt = 0
+    # We will look for the zero of phi between lower_bound and inf. 
+    # Therefore, the two have to be of different signs. 
+    if (phi(lower_bound) > 0) and (phi(inf) < 0): 
+        print('lower bound:', lower_bound)
+        # brentq is considered the best rootfinding routine. 
+        try: 
+            lambda_opt = optimize.brentq(phi, lower_bound, inf, xtol=xtol)
         except:
-            print('SRLS ERROR: Did not converge. Setting lambda to 0.')
-            lambda_opt = 0
+            print('SRLS error: brentq did not converge even though we found an estimate for lower and upper bonud. Setting lambda to 0.')
+    else: 
+        try: 
+            lambda_opt = optimize.newton(phi, lower_bound, fprime=phi_prime, maxiter=1000, tol=xtol, verbose=True)
+            assert phi(lambda_opt) < xtol, 'did not find solution of phi(lambda)=0:={}'.format(phi(lambda_opt))
+        except:
+            print('SRLS error: newton did not converge. Setting lambda to 0.')
 
     if (print_out):
-        print('phi(I_orig)', phi(I_orig))
+        print('phi(lower_bound)', phi(lower_bound))
         print('phi(inf)', phi(inf))
-        print('phi(opt)', phi(lambda_opt))
+        print('phi(lambda_opt)', phi(lambda_opt))
+        pos_definite = ATA + lambda_opt*D
+        eig = np.sort(np.real(eigvals(pos_definite)))
+        print('should be strictly bigger than 0:', eig)
 
     # Compute best estimate
     yhat = y_hat(lambda_opt)

--- a/pylocus/point_set.py
+++ b/pylocus/point_set.py
@@ -43,7 +43,7 @@ class PointSet:
         self.points = return_noisy_points(noise, indices, self.points.copy())
         self.init()
 
-    def set_points(self, mode, points=None, range_=RANGE, size=1):
+    def set_points(self, mode='', points=None, range_=RANGE, size=1):
         """ Initialize points according to predefined modes.
 
         :param range_:[xmin, xmax, ymin, ymax], range of point sets
@@ -174,6 +174,13 @@ class PointSet:
                                         (3.34, -1.36), (5, 1.4)))
             else:
                 print("Error: No rule defined for N = ", self.N)
+        elif mode == '':
+            if points is None:
+                raise NotImplementedError("Need to give either mode or points.")
+            else:
+                self.points = points
+                self.N, self.d = points.shape
+
         self.init()
 
     def create_edm(self):

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -32,11 +32,12 @@ class BaseCommon:
 
         def test_multiple(self):
             print('TestCommon:test_multiple')
-            for i in range(self.n_it):
-                self.test_zero_noise()
+            for i in range(self.n_it): # seed 381 used to fail.
+                np.random.seed(i)
+                self.test_zero_noise(it=i)
                 self.test_zero_noise_relaxed()
 
-        def test_zero_noise(self):
+        def test_zero_noise(self, it=0):
             print('TestCommon:test_zero_noise')
             for N in self.N_zero:
                 for d in (2, 3):
@@ -46,7 +47,8 @@ class BaseCommon:
                         if points_estimate is None:
                             continue
                         error = np.linalg.norm(self.pts.points - points_estimate) 
-                        self.assertTrue(error < self.eps, 'error: {} not smaller than {}'.format(error, self.eps))
+                        self.assertTrue(error < self.eps, 
+                                        'error (method={}, it={}, N={}, d={}): {} not smaller than {}'.format(method, it, N, d, error, self.eps))
 
         def test_zero_noise_relaxed(self):
             print('TestCommon:test_zero_noise_relaxed')

--- a/test/test_srls.py
+++ b/test/test_srls.py
@@ -20,16 +20,8 @@ class TestSRLS(BaseCommon.TestAlgorithms):
         self.eps = 1e-8
 
     def create_points(self, N=10, d=2):
-        print('TestSRLS:create_points')
         self.pts = PointSet(N, d)
         self.pts.set_points('random')
-        # example point set that fails:
-        # self.pts.points = np.array([[0.63, 0.45],
-        #  [0.35, 0.37],
-        #  [0.69, 0.71],
-        #  [0.71, 0.73],
-        #  [0.43, 0.44],
-        #  [0.58, 0.59]])
         self.pts.init()
         self.n = 1
 
@@ -46,15 +38,48 @@ class TestSRLS(BaseCommon.TestAlgorithms):
                                     W=np.ones(self.pts.edm.shape), rescale=False,
                                     z=self.pts.points[0, 2])
 
+    def test_fail(self):
+        # Example point set that used to fail. With the newer SRLS version this is fixed. 
+        # Status:  July 16, 2018
+        points_fail = np.array([[0.00250654, 0.89508715, 0.35528746],
+                                [0.52509683, 0.88692205, 0.76633946],
+                                [0.64764605, 0.94040708, 0.20720253],
+                                [0.69637586, 0.99566993, 0.49537693],
+                                [0.64455557, 0.46856155, 0.80050257],
+                                [0.90556836, 0.75831552, 0.81982037],
+                                [0.86634135, 0.5139182 , 0.14738743],
+                                [0.29145628, 0.54500108, 0.6586396 ]])
+        method = 'rescale'
+        self.pts.set_points(points=points_fail)
+        points_estimate = self.call_method(method=method)
+        error = np.linalg.norm(self.pts.points - points_estimate) 
+        self.assertTrue(error < self.eps, 
+                        'error: {} not smaller than {}'.format(error, self.eps))
+        
+        points_fail = np.array([[0.63, 0.45],
+                                [0.35, 0.37],
+                                [0.69, 0.71],
+                                [0.71, 0.73],
+                                [0.43, 0.44],
+                                [0.58, 0.59]])
+        method = 'normal'
+
+        self.pts.set_points(points=points_fail)
+        points_estimate = self.call_method(method=method)
+        error = np.linalg.norm(self.pts.points - points_estimate) 
+        self.assertTrue(error < self.eps, 
+                         'error: {} not smaller than {}'.format(error, self.eps))
+
     def test_multiple_weights(self):
-        print('TestSRLS:test_multiple')
-        for i in range(100):
+        print('TestSRLS:test_multiple_weights')
+        for i in range(self.n_it):
             self.create_points()
             self.zero_weights(0.0)
             self.zero_weights(0.1)
             self.zero_weights(1.0)
 
     def test_srls_rescale(self):
+        print('TestSRLS:test_srls_rescale')
         anchors = np.array([[0.,  8.44226166,  0.29734295],
                             [1.,  7.47840264,  1.41311759],
                             [2.,  8.08093318,  2.21959719],
@@ -83,6 +108,7 @@ class TestSRLS(BaseCommon.TestAlgorithms):
         np.testing.assert_allclose(x, x_srls_resc)
 
     def test_srls_fixed(self):
+        print('TestSRLS:test_srls_fixed')
         self.create_points(N=10, d=3)
         zreal = self.pts.points[0, 2]
         xhat = reconstruct_srls(self.pts.edm, self.pts.points, n=self.n, 
@@ -92,7 +118,6 @@ class TestSRLS(BaseCommon.TestAlgorithms):
         np.testing.assert_allclose(xhat, self.pts.points)
 
     def zero_weights(self, noise=0.1):
-        print('TestSRLS:test_zero_weights({})'.format(noise))
         index = np.arange(self.n)
         other = np.delete(range(self.pts.N), index)
         edm_noisy = create_noisy_edm(self.pts.edm, noise)


### PR DESCRIPTION
- Improved solver choice of SRLS: if we find a good upper and lower bound we will use brentq (which is better than bisect), and if we don't we use newton as before. 
- Removed the epsilon from interval choice, which made the method not find a good zero sometimes. Now the method is more true to the SRLS paper. 